### PR TITLE
Update Resend PHP SDK

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,22 +1,18 @@
 {
-    "name": "resend/laravel",
-    "description": "",
+    "name": "resend/resend-laravel",
+    "description": "Resend for Laravel",
     "keywords": ["php", "resend", "laravel", "sdk", "api", "client"],
     "license": "MIT",
     "authors": [
         {
-            "name": "Jayan Ratna",
-            "email": "jayan@pixelet.co"
-        },
-        {
             "name": "Resend and contributors",
-            "homepage": "https://github.com/jayanratna/resend-php/contributors"
+            "homepage": "https://github.com/resendlabs/resend-laravel/contributors"
         }
     ],
     "require": {
         "php": "^8.1.0",
         "illuminate/support": "^9.21|^10.0",
-        "resend/client": "^0.2.0",
+        "resend/resend-php": "^0.3.0",
         "symfony/mailer": "^6.2"
     },
     "require-dev": {

--- a/tests/Transport/ResendTransportFactory.php
+++ b/tests/Transport/ResendTransportFactory.php
@@ -28,7 +28,7 @@ test('send', function () {
         ->to('me@example.com')
         ->bcc('you@example.com');
 
-    $resendResult = new Sent('id', 'myself@example.com', 'me@example.com');
+    $resendResult = new Sent('id', 'myself@example.com', 'me@example.com', '2022-04-01');
 
     $client = mock(Client::class)->shouldReceive('sendEmail')
         ->once()


### PR DESCRIPTION
This PR updates the library to use `resend/resend-php` instead of `resend/client`.