### PR TITLE
chore: readme org name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Resend for Laravel
 
-[![Tests](https://img.shields.io/github/actions/workflow/status/jayanratna/resend-laravel/tests.yml?label=tests&style=for-the-badge&labelColor=000000)](https://github.com/jayanratna/resend-laravel/actions/workflows/tests.yml)
+[![Tests](https://img.shields.io/github/actions/workflow/status/resendlabs/resend-laravel/tests.yml?label=tests&style=for-the-badge&labelColor=000000)](https://github.com/resendlabs/resend-laravel/actions/workflows/tests.yml)
 [![Packagist Downloads](https://img.shields.io/packagist/dt/resend/resend-laravel?style=for-the-badge&labelColor=000000)](https://packagist.org/packages/resend/resend-laravel)
 [![Packagist Version](https://img.shields.io/packagist/v/resend/resend-laravel?style=for-the-badge&labelColor=000000)](https://packagist.org/packages/resend/resend-laravel)
-[![License](https://img.shields.io/github/license/jayanratna/resend-laravel?color=9cf&style=for-the-badge&labelColor=000000)](https://github.com/jayanratna/resend-laravel/blob/main/LICENSE)
+[![License](https://img.shields.io/github/license/resendlabs/resend-laravel?color=9cf&style=for-the-badge&labelColor=000000)](https://github.com/resendlabs/resend-laravel/blob/main/LICENSE)
 
 ---
 


### PR DESCRIPTION
I think when the move to the org was made, `resenlabs` forgot to change the org in the readme.
