### PR TITLE
feat: Add Facade to library

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Finally, you may use the `Resend` facade to access the Resend API:
 ```php
 use Resend\Laravel\Facades\Resend;
 
-Resend::sendEmail([
+Resend::emails()->send([
     'from' => 'onboarding@resend.dev',
     'to' => 'user@gmail.com',
     'subject' => 'hello world',

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "require": {
         "php": "^8.1",
         "illuminate/support": "^9.21|^10.0",
-        "resend/resend-php": "^0.5.2",
+        "resend/resend-php": "^0.5.3",
         "symfony/mailer": "^6.2"
     },
     "require-dev": {

--- a/src/Facades/Resend.php
+++ b/src/Facades/Resend.php
@@ -3,12 +3,27 @@
 namespace Resend\Laravel\Facades;
 
 use Illuminate\Support\Facades\Facade;
+use Resend\Service\ApiKey;
+use Resend\Service\Domain;
+use Resend\Service\Email;
 
-/**
- * @method static Resend\Responses\Email\EmailSent sendEmail(array $parameters)
- */
 class Resend extends Facade
 {
+    public static function apiKeys(): ApiKey
+    {
+        return static::getFacadeRoot()->apiKeys;
+    }
+
+    public static function domains(): Domain
+    {
+        return static::getFacadeRoot()->domains;
+    }
+
+    public static function emails(): Email
+    {
+        return static::getFacadeRoot()->emails;
+    }
+
     /**
      * Get the registered name of the component.
      */

--- a/tests/Facades/Resend.php
+++ b/tests/Facades/Resend.php
@@ -2,6 +2,9 @@
 
 use Resend\Client;
 use Resend\Laravel\Facades\Resend;
+use Resend\Service\ApiKey;
+use Resend\Service\Domain;
+use Resend\Service\Email;
 
 it('resolves Resend client', function () {
     $app = app();
@@ -11,4 +14,16 @@ it('resolves Resend client', function () {
     ]);
 
     expect(Resend::getFacadeRoot())->toBeInstanceOf(Client::class);
+});
+
+it('can get an API service', function () {
+    $app = app();
+
+    $app->get('config')->set('resend', [
+        'api_key' => 'test',
+    ]);
+
+    expect(Resend::apiKeys())->toBeInstanceOf(ApiKey::class)
+        ->and(Resend::domains())->toBeInstanceOf(Domain::class)
+        ->and(Resend::emails())->toBeInstanceOf(Email::class);
 });


### PR DESCRIPTION
This PR adds a `Resend` facade to the library. This can be useful for accessing the `Resend` client instance in the Laravel container to make API requests to Resend, such as:

```php
use Resend\Laravel\Facades\Resend;

Resend::apiKeys()->list();
Resend::domains()->remove('id');
Resend::emails()->send([...]);
```