### PR TITLE
fix: ensure email address parameters are sent as string arrays

### DIFF
--- a/src/Transport/ResendTransportFactory.php
+++ b/src/Transport/ResendTransportFactory.php
@@ -34,11 +34,11 @@ class ResendTransportFactory extends AbstractTransport
         try {
             $result = $this->resend->emails->send([
                 'from' => $envelope->getSender()->toString(),
-                'to' => implode(',', $this->stringifyAddresses($this->getRecipients($email, $envelope))),
+                'to' => $this->stringifyAddresses($this->getRecipients($email, $envelope)),
                 'subject' => $email->getSubject(),
-                'bcc' => implode(',', $this->stringifyAddresses($email->getBcc())),
-                'cc' => implode(',', $this->stringifyAddresses($email->getCc())),
-                'reply_to' => implode(',', $this->stringifyAddresses($email->getReplyTo())),
+                'bcc' => $this->stringifyAddresses($email->getBcc()),
+                'cc' => $this->stringifyAddresses($email->getCc()),
+                'reply_to' => $this->stringifyAddresses($email->getReplyTo()),
                 'text' => $email->getTextBody(),
                 'html' => $email->getHtmlBody(),
             ]);

--- a/tests/Transport/ResendTransportFactory.php
+++ b/tests/Transport/ResendTransportFactory.php
@@ -33,7 +33,7 @@ test('constructor', function () {
     expect($this->transporter)->toBeInstanceOf(ResendTransportFactory::class);
 });
 
-test('send', function () {
+test('can send', function () {
     $email = (new SymfonyEmail())
         ->from('from@example.com')
         ->to(new Address('to@example.com', 'Acme'))
@@ -60,6 +60,33 @@ test('send', function () {
                 $arg['cc'] === ['cc@example.com'] &&
                 $arg['bcc'] === ['bcc@example.com'] &&
                 $arg['reply_to'] === ['reply-to@example.com'];
+        }))
+        ->andReturn($apiResponse);
+
+    $this->transporter->send($email);
+});
+
+test('can send to multiple recipients', function () {
+    $email = (new SymfonyEmail())
+        ->from('from@example.com')
+        ->to(new Address('to@example.com', 'Acme'), new Address('sales@example.com', 'Acme Sales'))
+        ->subject('Test Subject')
+        ->text('Test plain text body')
+        ->html('<p>Test HTML body</p>');
+
+    $apiResponse = new Email([
+        'id' => '49a3999c-0ce1-4ea6-ab68-afcd6dc2e794',
+        'from' => 'from@example.com',
+        'to' => 'to@example.com',
+        'created_at' => '2022-07-25T00:28:32.493138+00:00',
+    ]);
+
+    $this->client->emails
+        ->shouldReceive('send')
+        ->once()
+        ->with(Mockery::on(function ($arg) {
+            return $arg['from'] === 'from@example.com' &&
+                $arg['to'] === ['"Acme" <to@example.com>', '"Acme Sales" <sales@example.com>'];
         }))
         ->andReturn($apiResponse);
 

--- a/tests/Transport/ResendTransportFactory.php
+++ b/tests/Transport/ResendTransportFactory.php
@@ -6,6 +6,7 @@ use Resend\Contracts\Client;
 use Resend\Email;
 use Resend\Laravel\Transport\ResendTransportFactory;
 use Resend\Service\Email as EmailService;
+use Symfony\Component\Mime\Address;
 use Symfony\Component\Mime\Email as SymfonyEmail;
 
 beforeEach(function () {
@@ -35,7 +36,7 @@ test('constructor', function () {
 test('send', function () {
     $email = (new SymfonyEmail())
         ->from('from@example.com')
-        ->to('to@example.com')
+        ->to(new Address('to@example.com', 'Acme'))
         ->cc('cc@example.com')
         ->bcc('bcc@example.com')
         ->replyTo('reply-to@example.com')
@@ -55,8 +56,10 @@ test('send', function () {
         ->once()
         ->with(Mockery::on(function ($arg) {
             return $arg['from'] === 'from@example.com' &&
-                $arg['to'] === 'to@example.com' &&
-                $arg['bcc'] === 'bcc@example.com';
+                $arg['to'] === ['"Acme" <to@example.com>'] &&
+                $arg['cc'] === ['cc@example.com'] &&
+                $arg['bcc'] === ['bcc@example.com'] &&
+                $arg['reply_to'] === ['reply-to@example.com'];
         }))
         ->andReturn($apiResponse);
 


### PR DESCRIPTION
This PR ensures that all email address recipient parameters (`to`, `cc`, `bcc`, and `reply_to`) are converted to string arrays before making a API request to Resend.

This PR also adds an additional test that ensures multiple recipients are correctly handled when the API request is made.

Fixes #30