### PR TITLE
feat: add support for headers

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "require": {
         "php": "^8.1",
         "illuminate/support": "^9.21|^10.0",
-        "resend/resend-php": "^0.7.0",
+        "resend/resend-php": "^0.7.1",
         "symfony/mailer": "^6.2"
     },
     "require-dev": {


### PR DESCRIPTION
This PR adds support for headers in the Symfony `ResendTransport`. Tests have also been added to ensure headers are correctly sent to the API. The `Resend` Facade can already make use of `headers` in emails.