### PR TITLE
feat: set X-Resend-Email-ID after the email is sent

### DIFF
--- a/src/Transport/ResendTransportFactory.php
+++ b/src/Transport/ResendTransportFactory.php
@@ -60,6 +60,10 @@ class ResendTransportFactory extends AbstractTransport
                 $exception
             );
         }
+
+        $messageId = $result->id;
+
+        $email->getHeaders()->addHeader('X-Resend-Email-ID', $messageId);
     }
 
     /**


### PR DESCRIPTION
This PR will set a `X-Resend-Email-ID` header on the `SentMessage` instance. This allows developers to get the ID of the email that was sent via the Resend API.