### PR TITLE
feat: add VerifyWebhookSignature middleware

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "require": {
         "php": "^8.1",
         "illuminate/support": "^9.21|^10.0",
-        "resend/resend-php": "dev-main",
+        "resend/resend-php": "^0.8.0",
         "symfony/mailer": "^6.2"
     },
     "require-dev": {
@@ -22,12 +22,6 @@
         "orchestra/testbench": "^7.22|^8.0",
         "pestphp/pest": "^1.22"
     },
-    "repositories": [
-        {
-            "type": "path",
-            "url": "../resend-php"
-        }
-    ],
     "autoload": {
         "psr-4": {
             "Resend\\Laravel\\": "src/"

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "require": {
         "php": "^8.1",
         "illuminate/support": "^9.21|^10.0",
-        "resend/resend-php": "^0.7.1",
+        "resend/resend-php": "dev-main",
         "symfony/mailer": "^6.2"
     },
     "require-dev": {
@@ -22,6 +22,12 @@
         "orchestra/testbench": "^7.22|^8.0",
         "pestphp/pest": "^1.22"
     },
+    "repositories": [
+        {
+            "type": "path",
+            "url": "../resend-php"
+        }
+    ],
     "autoload": {
         "psr-4": {
             "Resend\\Laravel\\": "src/"

--- a/src/Http/Controllers/WebhookController.php
+++ b/src/Http/Controllers/WebhookController.php
@@ -12,10 +12,21 @@ use Resend\Laravel\Events\EmailDelivered;
 use Resend\Laravel\Events\EmailDeliveryDelayed;
 use Resend\Laravel\Events\EmailOpened;
 use Resend\Laravel\Events\EmailSent;
+use Resend\Laravel\Http\Middleware\VerifyWebhookSignature;
 use Symfony\Component\HttpFoundation\Response;
 
 class WebhookController extends Controller
 {
+    /**
+     * Create a new webhook controller instance.
+     */
+    public function __construct()
+    {
+        if (config('resend.webhook.secret')) {
+            $this->middleware(VerifyWebhookSignature::class);
+        }
+    }
+
     /**
      * Handle a Resend webhook call.
      */

--- a/src/Http/Middleware/VerifyWebhookSignature.php
+++ b/src/Http/Middleware/VerifyWebhookSignature.php
@@ -2,6 +2,37 @@
 
 namespace Resend\Laravel\Http\Middleware;
 
+use Closure;
+use Exception;
+use Illuminate\Http\Request;
+use Resend\WebhookSignature;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+
 class VerifyWebhookSignature
 {
+    /**
+     * Handle an incoming request.
+     *
+     * @param \Illuminate\Http\Request $request
+     * @param \Closure(\Illuminate\Http\Request): (\Symfony\Component\HttpFoundation\Response) $next
+     */
+    public function handle(Request $request, Closure $next)
+    {
+        try {
+            $headers = collect($request->headers->all())->transform(function ($item) {
+                return $item[0];
+            })->all();
+
+            WebhookSignature::verify(
+                $request->getContent(),
+                $headers,
+                config('resend.webhook.secret'),
+                config('resend.webhook.tolerance')
+            );
+        } catch (Exception $exception) {
+            throw new AccessDeniedHttpException($exception->getMessage(), $exception);
+        }
+
+        return $next($request);
+    }
 }

--- a/tests/Http/Middleware/VerifyWebhookSignature.php
+++ b/tests/Http/Middleware/VerifyWebhookSignature.php
@@ -1,0 +1,48 @@
+<?php
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+use Resend\Laravel\Http\Middleware\VerifyWebhookSignature;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+
+function withSignature(Request $request, string $secret, int $timestamp): void
+{
+    $payload = $request->getContent();
+    $id = '123';
+
+    $toSign = $id . '.' . $timestamp . '.' . $payload;
+    $signature = base64_encode(pack('H*', hash_hmac('sha256', $toSign, base64_decode($secret))));
+
+    $request->headers->set('svix-id', $id);
+    $request->headers->set('svix-timestamp', $timestamp);
+    $request->headers->set('svix-signature', 'v1,' . $signature);
+}
+
+beforeEach(function () {
+    config(['resend.webhook.secret' => 'secret']);
+    config(['resend.webhook.tolerance' => 300]);
+});
+
+it('recieves a response when a signature is verified', function () {
+    $request = webhookRequest('email.delivered');
+    $timestamp = time();
+
+    withSignature($request, 'secret', $timestamp);
+
+    $response = (new VerifyWebhookSignature())->handle($request, function () {
+        return new Response('OK');
+    });
+
+    expect($response->getContent())->toBe('OK');
+});
+
+it('throws an exception when the secret cannot be verified', function () {
+    $request = webhookRequest('email.delivered');
+    $timestamp = time();
+
+    withSignature($request, 'secret', $timestamp + 400);
+
+    (new VerifyWebhookSignature())->handle($request, function () {
+        return new Response('OK');
+    });
+})->throws(AccessDeniedHttpException::class, 'Message timestamp too new');

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,5 +1,14 @@
 <?php
 
+use Illuminate\Http\Request;
 use Resend\Laravel\Tests\TestCase;
 
 uses(TestCase::class)->in(__DIR__);
+
+function webhookRequest(string $event): Request
+{
+    return Request::create('/', 'POST', [], [], [], [], json_encode([
+        'id' => 're_evt_123456789',
+        'type' => $event,
+    ]));
+}


### PR DESCRIPTION
This PR adds a `VerifyWebhookSignature` middleware to verify webhook requests to `/resend/webhook` route.

Depends on https://github.com/resendlabs/resend-php/pull/40