### PR TITLE
chore: Ignore config files from export

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,5 +4,8 @@
 .editorconfig      export-ignore
 .gitattributes     export-ignore
 .gitignore         export-ignore
+.php-cs-fixer.php  export-ignore
 phpunit.xml.dist   export-ignore
+phpunit.xml        export-ignore
 README.md          export-ignore
+renovate.json      export-ignore


### PR DESCRIPTION
This PR ensures that config and test specific files are not included in an export. An export is usually when composer downloads the library on an application.