### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,6 +8,9 @@ on:
   schedule:
     - cron: '0 0 * * *'
 
+permissions:
+  contents: read
+
 jobs:
   tests:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
Potential fix for [https://github.com/resend/resend-laravel/security/code-scanning/1](https://github.com/resend/resend-laravel/security/code-scanning/1)

To fix the issue, add a `permissions` block at the root of the workflow file to explicitly define the permissions required for the workflow. Since the workflow primarily reads repository contents and does not perform write operations, the permissions can be limited to `contents: read`. This change ensures that the `GITHUB_TOKEN` has only the necessary access, reducing the risk of misuse.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
