### PR TITLE
Forward Svix webhook headers to dispatched events

### DIFF
--- a/src/Events/ContactCreated.php
+++ b/src/Events/ContactCreated.php
@@ -13,7 +13,8 @@ class ContactCreated
      * Create a new contact created event instance.
      */
     public function __construct(
-        public array $payload
+        public array $payload,
+        public array $headers = []
     ) {
         //
     }

--- a/src/Events/ContactDeleted.php
+++ b/src/Events/ContactDeleted.php
@@ -13,7 +13,8 @@ class ContactDeleted
      * Create a new contact deleted event instance.
      */
     public function __construct(
-        public array $payload
+        public array $payload,
+        public array $headers = []
     ) {
         //
     }

--- a/src/Events/ContactUpdated.php
+++ b/src/Events/ContactUpdated.php
@@ -13,7 +13,8 @@ class ContactUpdated
      * Create a new contact updated event instance.
      */
     public function __construct(
-        public array $payload
+        public array $payload,
+        public array $headers = []
     ) {
         //
     }

--- a/src/Events/DomainCreated.php
+++ b/src/Events/DomainCreated.php
@@ -13,7 +13,8 @@ class DomainCreated
      * Create a new domain created event instance.
      */
     public function __construct(
-        public array $payload
+        public array $payload,
+        public array $headers = []
     ) {
         //
     }

--- a/src/Events/DomainDeleted.php
+++ b/src/Events/DomainDeleted.php
@@ -13,7 +13,8 @@ class DomainDeleted
      * Create a new domain deleted event instance.
      */
     public function __construct(
-        public array $payload
+        public array $payload,
+        public array $headers = []
     ) {
         //
     }

--- a/src/Events/DomainUpdated.php
+++ b/src/Events/DomainUpdated.php
@@ -13,7 +13,8 @@ class DomainUpdated
      * Create a new domain updated event instance.
      */
     public function __construct(
-        public array $payload
+        public array $payload,
+        public array $headers = []
     ) {
         //
     }

--- a/src/Events/EmailBounced.php
+++ b/src/Events/EmailBounced.php
@@ -13,7 +13,8 @@ class EmailBounced
      * Create a new email bounced event instance.
      */
     public function __construct(
-        public array $payload
+        public array $payload,
+        public array $headers = []
     ) {
         //
     }

--- a/src/Events/EmailClicked.php
+++ b/src/Events/EmailClicked.php
@@ -13,7 +13,8 @@ class EmailClicked
      * Create a new email clicked event instance.
      */
     public function __construct(
-        public array $payload
+        public array $payload,
+        public array $headers = []
     ) {
         //
     }

--- a/src/Events/EmailComplained.php
+++ b/src/Events/EmailComplained.php
@@ -13,7 +13,8 @@ class EmailComplained
      * Create a new email complained event instance.
      */
     public function __construct(
-        public array $payload
+        public array $payload,
+        public array $headers = []
     ) {
         //
     }

--- a/src/Events/EmailDelivered.php
+++ b/src/Events/EmailDelivered.php
@@ -13,7 +13,8 @@ class EmailDelivered
      * Create a new email delivered event instance.
      */
     public function __construct(
-        public array $payload
+        public array $payload,
+        public array $headers = []
     ) {
         //
     }

--- a/src/Events/EmailDeliveryDelayed.php
+++ b/src/Events/EmailDeliveryDelayed.php
@@ -13,7 +13,8 @@ class EmailDeliveryDelayed
      * Create a new delivery delayed event instance.
      */
     public function __construct(
-        public array $payload
+        public array $payload,
+        public array $headers = []
     ) {
         //
     }

--- a/src/Events/EmailFailed.php
+++ b/src/Events/EmailFailed.php
@@ -13,7 +13,8 @@ class EmailFailed
      * Create a new email failed event instance.
      */
     public function __construct(
-        public array $payload
+        public array $payload,
+        public array $headers = []
     ) {
         //
     }

--- a/src/Events/EmailOpened.php
+++ b/src/Events/EmailOpened.php
@@ -13,7 +13,8 @@ class EmailOpened
      * Create a new email opened event instance.
      */
     public function __construct(
-        public array $payload
+        public array $payload,
+        public array $headers = []
     ) {
         //
     }

--- a/src/Events/EmailReceived.php
+++ b/src/Events/EmailReceived.php
@@ -13,7 +13,8 @@ class EmailReceived
      * Create a new email received event instance.
      */
     public function __construct(
-        public array $payload
+        public array $payload,
+        public array $headers = []
     ) {
         //
     }

--- a/src/Events/EmailSent.php
+++ b/src/Events/EmailSent.php
@@ -13,7 +13,8 @@ class EmailSent
      * Create a new email sent event instance.
      */
     public function __construct(
-        public array $payload
+        public array $payload,
+        public array $headers = []
     ) {
         //
     }

--- a/src/Events/EmailSuppressed.php
+++ b/src/Events/EmailSuppressed.php
@@ -13,7 +13,8 @@ class EmailSuppressed
      * Create a new email suppressed event instance.
      */
     public function __construct(
-        public array $payload
+        public array $payload,
+        public array $headers = []
     ) {
         //
     }

--- a/src/Http/Controllers/WebhookController.php
+++ b/src/Http/Controllers/WebhookController.php
@@ -47,10 +47,12 @@ class WebhookController extends Controller
             return new Response('Invalid payload', 400);
         }
 
+        $headers = $this->extractHeaders($request);
+
         $method = 'handle' . Str::studly(str_replace('.', '_', $payload['type']));
 
         if (method_exists($this, $method)) {
-            $response = $this->{$method}($payload);
+            $response = $this->{$method}($payload, $headers);
 
             return $response;
         }
@@ -59,11 +61,25 @@ class WebhookController extends Controller
     }
 
     /**
+     * Extract the Svix webhook headers from the request so listeners can use
+     * them (e.g. `svix-id` as a deduplication key).
+     *
+     * @return array<string, string>
+     */
+    protected function extractHeaders(Request $request): array
+    {
+        return collect(['svix-id', 'svix-timestamp', 'svix-signature'])
+            ->mapWithKeys(fn (string $key) => [$key => $request->header($key)])
+            ->filter()
+            ->all();
+    }
+
+    /**
      * Handle contact created event.
      */
-    protected function handleContactCreated(array $payload): Response
+    protected function handleContactCreated(array $payload, array $headers = []): Response
     {
-        ContactCreated::dispatch($payload);
+        ContactCreated::dispatch($payload, $headers);
 
         return $this->successMethod();
     }
@@ -71,9 +87,9 @@ class WebhookController extends Controller
     /**
      * Handle contact deleted event.
      */
-    protected function handleContactDeleted(array $payload): Response
+    protected function handleContactDeleted(array $payload, array $headers = []): Response
     {
-        ContactDeleted::dispatch($payload);
+        ContactDeleted::dispatch($payload, $headers);
 
         return $this->successMethod();
     }
@@ -81,9 +97,9 @@ class WebhookController extends Controller
     /**
      * Handle contact updated event.
      */
-    protected function handleContactUpdated(array $payload): Response
+    protected function handleContactUpdated(array $payload, array $headers = []): Response
     {
-        ContactUpdated::dispatch($payload);
+        ContactUpdated::dispatch($payload, $headers);
 
         return $this->successMethod();
     }
@@ -91,9 +107,9 @@ class WebhookController extends Controller
     /**
      * Handle domain created event.
      */
-    protected function handleDomainCreated(array $payload): Response
+    protected function handleDomainCreated(array $payload, array $headers = []): Response
     {
-        DomainCreated::dispatch($payload);
+        DomainCreated::dispatch($payload, $headers);
 
         return $this->successMethod();
     }
@@ -101,9 +117,9 @@ class WebhookController extends Controller
     /**
      * Handle domain deleted event.
      */
-    protected function handleDomainDeleted(array $payload): Response
+    protected function handleDomainDeleted(array $payload, array $headers = []): Response
     {
-        DomainDeleted::dispatch($payload);
+        DomainDeleted::dispatch($payload, $headers);
 
         return $this->successMethod();
     }
@@ -111,9 +127,9 @@ class WebhookController extends Controller
     /**
      * Handle domain updated event.
      */
-    protected function handleDomainUpdated(array $payload): Response
+    protected function handleDomainUpdated(array $payload, array $headers = []): Response
     {
-        DomainUpdated::dispatch($payload);
+        DomainUpdated::dispatch($payload, $headers);
 
         return $this->successMethod();
     }
@@ -121,9 +137,9 @@ class WebhookController extends Controller
     /**
      * Handle email bounced event.
      */
-    protected function handleEmailBounced(array $payload): Response
+    protected function handleEmailBounced(array $payload, array $headers = []): Response
     {
-        EmailBounced::dispatch($payload);
+        EmailBounced::dispatch($payload, $headers);
 
         return $this->successMethod();
     }
@@ -131,9 +147,9 @@ class WebhookController extends Controller
     /**
      * Handle email clicked event.
      */
-    protected function handleEmailClicked(array $payload): Response
+    protected function handleEmailClicked(array $payload, array $headers = []): Response
     {
-        EmailClicked::dispatch($payload);
+        EmailClicked::dispatch($payload, $headers);
 
         return $this->successMethod();
     }
@@ -141,9 +157,9 @@ class WebhookController extends Controller
     /**
      * Handle email complained event.
      */
-    protected function handleEmailComplained(array $payload): Response
+    protected function handleEmailComplained(array $payload, array $headers = []): Response
     {
-        EmailComplained::dispatch($payload);
+        EmailComplained::dispatch($payload, $headers);
 
         return $this->successMethod();
     }
@@ -151,9 +167,9 @@ class WebhookController extends Controller
     /**
      * Handle email delivered event.
      */
-    protected function handleEmailDelivered(array $payload): Response
+    protected function handleEmailDelivered(array $payload, array $headers = []): Response
     {
-        EmailDelivered::dispatch($payload);
+        EmailDelivered::dispatch($payload, $headers);
 
         return $this->successMethod();
     }
@@ -161,9 +177,9 @@ class WebhookController extends Controller
     /**
      * Handle email delivery delayed event.
      */
-    protected function handleEmailDeliveryDelayed(array $payload): Response
+    protected function handleEmailDeliveryDelayed(array $payload, array $headers = []): Response
     {
-        EmailDeliveryDelayed::dispatch($payload);
+        EmailDeliveryDelayed::dispatch($payload, $headers);
 
         return $this->successMethod();
     }
@@ -171,9 +187,9 @@ class WebhookController extends Controller
     /**
      * Handle email opened event.
      */
-    protected function handleEmailOpened(array $payload): Response
+    protected function handleEmailOpened(array $payload, array $headers = []): Response
     {
-        EmailOpened::dispatch($payload);
+        EmailOpened::dispatch($payload, $headers);
 
         return $this->successMethod();
     }
@@ -181,9 +197,9 @@ class WebhookController extends Controller
     /**
      * Handle email sent event.
      */
-    protected function handleEmailSent(array $payload): Response
+    protected function handleEmailSent(array $payload, array $headers = []): Response
     {
-        EmailSent::dispatch($payload);
+        EmailSent::dispatch($payload, $headers);
 
         return $this->successMethod();
     }
@@ -191,9 +207,9 @@ class WebhookController extends Controller
     /**
      * Handle email failed event.
      */
-    protected function handleEmailFailed(array $payload): Response
+    protected function handleEmailFailed(array $payload, array $headers = []): Response
     {
-        EmailFailed::dispatch($payload);
+        EmailFailed::dispatch($payload, $headers);
 
         return $this->successMethod();
     }
@@ -201,9 +217,9 @@ class WebhookController extends Controller
     /**
      * Handle email suppressed event.
      */
-    protected function handleEmailSuppressed(array $payload): Response
+    protected function handleEmailSuppressed(array $payload, array $headers = []): Response
     {
-        EmailSuppressed::dispatch($payload);
+        EmailSuppressed::dispatch($payload, $headers);
 
         return $this->successMethod();
     }
@@ -211,9 +227,9 @@ class WebhookController extends Controller
     /**
      * Handle email received event.
      */
-    protected function handleEmailReceived(array $payload): Response
+    protected function handleEmailReceived(array $payload, array $headers = []): Response
     {
-        EmailReceived::dispatch($payload);
+        EmailReceived::dispatch($payload, $headers);
 
         return $this->successMethod();
     }

--- a/tests/Http/Controllers/WebhookController.php
+++ b/tests/Http/Controllers/WebhookController.php
@@ -29,7 +29,12 @@ test('correct methods are called and handled based on resend webhook event', fun
     $response = (new Controller)->handleWebhook($request);
 
     Event::assertDispatched($event, function ($e) use ($request) {
-        return $request->getContent() == json_encode($e->payload);
+        return $request->getContent() == json_encode($e->payload)
+            && $e->headers === [
+                'svix-id' => 'msg_123456789',
+                'svix-timestamp' => '1614265330',
+                'svix-signature' => 'v1,exampleSignature',
+            ];
     });
 
     expect($response->getStatusCode())->toBe(200)
@@ -52,6 +57,33 @@ test('correct methods are called and handled based on resend webhook event', fun
     ['email.suppressed', EmailSuppressed::class],
     ['email.received', EmailReceived::class],
 ]);
+
+test('svix-id is forwarded to the event so it can be used as a dedup key', function () {
+    $request = webhookRequest('email.sent');
+
+    Event::fake([EmailSent::class]);
+
+    (new Controller)->handleWebhook($request);
+
+    Event::assertDispatched(EmailSent::class, function ($e) {
+        return $e->headers['svix-id'] === 'msg_123456789';
+    });
+});
+
+test('event receives empty headers when svix headers are absent', function () {
+    $request = Illuminate\Http\Request::create('/', 'POST', [], [], [], [], json_encode([
+        'id' => 're_evt_123456789',
+        'type' => 'email.sent',
+    ]));
+
+    Event::fake([EmailSent::class]);
+
+    (new Controller)->handleWebhook($request);
+
+    Event::assertDispatched(EmailSent::class, function ($e) {
+        return $e->headers === [];
+    });
+});
 
 test('normal response is returned if method is missing', function () {
     $request = webhookRequest('email.foo');

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -7,8 +7,14 @@ uses(TestCase::class)->in(__DIR__);
 
 function webhookRequest(string $event): Request
 {
-    return Request::create('/', 'POST', [], [], [], [], json_encode([
+    $request = Request::create('/', 'POST', [], [], [], [], json_encode([
         'id' => 're_evt_123456789',
         'type' => $event,
     ]));
+
+    $request->headers->set('svix-id', 'msg_123456789');
+    $request->headers->set('svix-timestamp', '1614265330');
+    $request->headers->set('svix-signature', 'v1,exampleSignature');
+
+    return $request;
 }


### PR DESCRIPTION
## Summary

Forwards the Svix webhook headers to dispatched events so listeners can access `svix-id` (and `svix-timestamp` / `svix-signature`) — most importantly to use `svix-id` as a **deduplication key**.

Closes #109.

## Problem

`WebhookController` decoded the request body and dispatched events with only that body:

```php
$payload = json_decode($request->getContent(), true);
EmailSent::dispatch($payload); // svix-id dropped here
```

The `svix-*` headers are present on the request (the `VerifyWebhookSignature` middleware even reads them to verify the signature), but they were never forwarded to the event, so listeners had no dedup key.

This is a Laravel-layer gap only: in the underlying `resend-php` SDK you call `WebhookSignature::verify($payload, $headers, $secret)` and keep the headers yourself. `resend-laravel` owns the request→event pipeline, so it has to pass them on.

## Change

- The controller now extracts the `svix-*` headers and passes them to every event as a **separate `$headers` property** — mirroring how the php SDK keeps headers beside the payload rather than merging them in.
- Scoped to `svix-*` so `authorization` / `cookie` / other request headers never leak into serialized or queued events.
- The property is defaulted (`public array $headers = []`), so this is **backwards compatible** — existing listeners and any manual `Event::dispatch($payload)` calls are unaffected.

```php
public function handle(EmailSent $event): void
{
    $event->headers['svix-id']; // dedup key
    $event->payload;            // unchanged
}
```

## Tests

- Existing parametrized controller test now asserts header forwarding across all 16 event types.
- Added: `svix-id` usable as a dedup key.
- Added: event receives empty `$headers` when no svix headers are present.
