### PR TITLE
chore: use the API timestamp format in test fixtures

### DIFF
--- a/tests/Transport/ResendTransportFactory.php
+++ b/tests/Transport/ResendTransportFactory.php
@@ -50,7 +50,7 @@ it('can send', function () {
         'id' => '49a3999c-0ce1-4ea6-ab68-afcd6dc2e794',
         'from' => 'from@example.com',
         'to' => 'to@example.com',
-        'created_at' => '2022-07-25T00:28:32.493138+00:00',
+        'created_at' => '2022-07-25 00:28:32.493138+00',
     ]);
 
     $this->client->emails
@@ -80,7 +80,7 @@ it('can send to multiple recipients', function () {
         'id' => '49a3999c-0ce1-4ea6-ab68-afcd6dc2e794',
         'from' => 'from@example.com',
         'to' => 'to@example.com',
-        'created_at' => '2022-07-25T00:28:32.493138+00:00',
+        'created_at' => '2022-07-25 00:28:32.493138+00',
     ]);
 
     $this->client->emails


### PR DESCRIPTION
## Context for reviewers

The Resend API returns timestamps in Postgres text format: `YYYY-MM-DD HH:MM:SS[.ffffff]+00` (for example `2023-10-06 23:47:56.678+00`). It is not ISO 8601. Fractional seconds vary from zero to six digits, so no fixed width can be assumed.

Our docs, OpenAPI spec, and SDK test fixtures claimed ISO 8601 for a long time. We fixed the docs and the spec, and we are now updating every SDK so the fixtures show what the API really sends. The SDKs treat these values as opaque strings, so behavior does not change.

ISO 8601 remains correct in three places: `scheduled_at` as a request parameter, webhook event payloads (millisecond precision with `Z`), and `revoked_at` in the DELETE `/oauth/grants/{id}` response.

## What

Convert the two `created_at` fixtures in `tests/Transport/ResendTransportFactory.php` from ISO 8601 to the real Postgres text format.

## Verification

- `vendor/bin/pest`: 44 passed (99 assertions).