### PR TITLE
feat(automations): duplicate endpoint

### DIFF
--- a/src/Facades/Resend.php
+++ b/src/Facades/Resend.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Facades\Facade;
  *
  * @method static \Resend\Service\ApiKey apiKeys()
  * @method static \Resend\Service\Audience audiences()
+ * @method static \Resend\Service\Automation automations()
  * @method static \Resend\Service\Batch batch()
  * @method static \Resend\Service\Broadcast broadcasts()
  * @method static \Resend\Service\Contact contacts()

--- a/tests/Facades/Resend.php
+++ b/tests/Facades/Resend.php
@@ -4,6 +4,7 @@ use Resend\Client;
 use Resend\Laravel\Facades\Resend;
 use Resend\Service\ApiKey;
 use Resend\Service\Audience;
+use Resend\Service\Automation;
 use Resend\Service\Batch;
 use Resend\Service\Broadcast;
 use Resend\Service\Contact;
@@ -34,6 +35,7 @@ it('can get an API service', function () {
 
     expect(Resend::apiKeys())->toBeInstanceOf(ApiKey::class)
         ->and(Resend::audiences())->toBeInstanceOf(Audience::class)
+        ->and(Resend::automations())->toBeInstanceOf(Automation::class)
         ->and(Resend::batch())->toBeInstanceOf(Batch::class)
         ->and(Resend::broadcasts())->toBeInstanceOf(Broadcast::class)
         ->and(Resend::contacts())->toBeInstanceOf(Contact::class)


### PR DESCRIPTION
Exposes `Resend::automations()` through the facade so the automations service — including the new `duplicate()` endpoint from resend-php — is available in Laravel.

Resolves DEV-1706. Counterpart to resend-php https://github.com/resend/resend-php/pull/136 and resend-node https://github.com/resend/resend-node/pull/1071.

🤖 Generated with [Claude Code](https://claude.com/claude-code)