### PR TITLE
docs(webhooks): add event listing example

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,18 @@ Resend::emails()->send([
 ]);
 ```
 
+### Listing webhook events
+
+The `Resend` facade exposes webhook events and their delivery attempts:
+
+```php
+$events = Resend::webhooks()->events->list($webhookId);
+
+$event = Resend::webhooks()->events->get($webhookId, $eventId);
+
+$attempts = Resend::webhooks()->events->attempts->list($webhookId, $eventId);
+```
+
 ### Using Resend's Laravel mailer
 
 Resend for Laravel comes bundled with a Laravel mailer to make it easier to send emails. To start using the Resend mail transport, first create a new mailer definition within your application's `config/mail.php` configuration file:

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "php": "^8.1",
         "illuminate/http": "^10.0|^11.0|^12.0|^13.0",
         "illuminate/support": "^10.0|^11.0|^12.0|^13.0",
-        "resend/resend-php": "^1.0.0",
+        "resend/resend-php": "^1.12.0",
         "symfony/mailer": "^6.2|^7.0|^8.0"
     },
     "require-dev": {


### PR DESCRIPTION
Documents the Laravel facade paths for listing webhook events, retrieving an event, and listing its delivery attempts.

Requires the upcoming `resend/resend-php` v1.12.0 release containing https://github.com/resend/resend-php/pull/144. This PR is intentionally stacked on that release; hosted Composer jobs will unblock once v1.12.0 is published.

Linear: https://linear.app/resend/issue/DEV-1924/laravel-sdk-external-jayan-via-slack-team-sdks

Checks:
- `composer validate --strict --no-check-publish`
- 44 Pest tests / 100 assertions using the local PHP SDK as v1.12.0
- live Keychain-authenticated Laravel facade calls: 7 webhooks, 100 events, `webhook_event` detail object, 1 delivery attempt